### PR TITLE
Get doesn't crash for tables without primary key.

### DIFF
--- a/src/RestDb/APIs/Get/GetTableSelect.cs
+++ b/src/RestDb/APIs/Get/GetTableSelect.cs
@@ -117,10 +117,9 @@ namespace RestDb
                 }
             }
 
-            int? index_start = resultOrder == null ? null : md.Params.IndexStart;
             result = db.Select(
                 tableName, 
-                index_start,
+                md.Params.IndexStart, 
                 md.Params.MaxResults, 
                 md.Params.ReturnFields, 
                 filter, 

--- a/src/RestDb/APIs/Get/GetTableSelect.cs
+++ b/src/RestDb/APIs/Get/GetTableSelect.cs
@@ -58,8 +58,12 @@ namespace RestDb
 
             DataTable result = null;
             Expr filter = null;
-            ResultOrder[] resultOrder = new ResultOrder[1];
-            resultOrder[0] = new ResultOrder(currTable.PrimaryKey, OrderDirectionEnum.Ascending);
+            ResultOrder[] resultOrder = null;
+            if (!string.IsNullOrWhiteSpace(currTable.PrimaryKey))
+            {
+                resultOrder = new ResultOrder[1];
+                resultOrder[0] = new ResultOrder(currTable.PrimaryKey, OrderDirectionEnum.Ascending);
+            }
 
             if (idVal > 0)
             {
@@ -113,9 +117,10 @@ namespace RestDb
                 }
             }
 
+            int? index_start = resultOrder == null ? null : md.Params.IndexStart;
             result = db.Select(
                 tableName, 
-                md.Params.IndexStart, 
+                index_start,
                 md.Params.MaxResults, 
                 md.Params.ReturnFields, 
                 filter, 

--- a/src/RestDb/Classes/RequestParameters.cs
+++ b/src/RestDb/Classes/RequestParameters.cs
@@ -99,7 +99,7 @@ namespace RestDb.Classes
 
         #region Private-Members
 
-        private int? _IndexStart = 0;
+        private int? _IndexStart = null;
         private int? _MaxResults = 100;
 
         #endregion


### PR DESCRIPTION
The GET request doesn't crash anymore for the tables without primary keys.

Rationale: Sometimes the table definition cannot be  modified in any way.
