### PR TITLE
Updated to Watson 6.1.5. This required adding code to handle OPTIONS requests

### DIFF
--- a/src/RestDb/Classes/AuthManager.cs
+++ b/src/RestDb/Classes/AuthManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using WatsonWebserver;
+using WatsonWebserver.Core;
 using SyslogLogging;
 
 namespace RestDb

--- a/src/RestDb/RestDb.csproj
+++ b/src/RestDb/RestDb.csproj
@@ -41,7 +41,8 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="SyslogLogging" Version="2.0.2" />
 		<PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
-		<PackageReference Include="Watson" Version="5.1.1" />
+		<PackageReference Include="Watson" Version="6.1.5" />
+		<PackageReference Include="Watson.Core" Version="6.1.5" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Originally I was debugging a problem with JavaScript fetch failing on RestDb. The server reported an internal error, thus, in order to debug it, I first upgraded to the latest Watson up from 5.1.1.

Let me know if there are better ways to tackle the problem.
